### PR TITLE
Update prices_bnb_tokens.sql

### DIFF
--- a/models/prices/bnb/prices_bnb_tokens.sql
+++ b/models/prices/bnb/prices_bnb_tokens.sql
@@ -199,8 +199,8 @@ FROM
     ("ghny-grizzly-honey","bnb","GHNY","0xa045e37a0d1dd3a45fefb8803d22457abc0a728a",18),
     ("grain-granary","bnb","GRAIN","0x8f87a7d376821c7b2658a005aaf190ec778bf37a",18),
     ("oath-oath","bnb","OATH","0xd3c6ceedd1cc7bd4304f72b011d53441d631e662",18),
-    ("edu-open-campus", "bnb", "EDU", "0xbdeae1ca48894a1759a8374d63925f21f2ee2639", 18),
-    ("id-space-id", "bnb", "ID", "0x2dff88a56767223a5529ea5960da7a3f5f766406", 18)
+    ("edu-edu-coin", "bnb", "EDU", "0xbdeae1ca48894a1759a8374d63925f21f2ee2639", 18),
+    ("id2-space-id", "bnb", "ID", "0x2dff88a56767223a5529ea5960da7a3f5f766406", 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
 where contract_address not in (
     '0x2ab0e9e4ee70fff1fb9d67031e44f6410170d00e', -- bXEN has bad price feed.

--- a/models/prices/bnb/prices_bnb_tokens.sql
+++ b/models/prices/bnb/prices_bnb_tokens.sql
@@ -198,7 +198,9 @@ FROM
     ("lvl-level","bnb","LVL","0xb64e280e9d1b5dbec4accedb2257a87b400db149",18),
     ("ghny-grizzly-honey","bnb","GHNY","0xa045e37a0d1dd3a45fefb8803d22457abc0a728a",18),
     ("grain-granary","bnb","GRAIN","0x8f87a7d376821c7b2658a005aaf190ec778bf37a",18),
-    ("oath-oath","bnb","OATH","0xd3c6ceedd1cc7bd4304f72b011d53441d631e662",18)
+    ("oath-oath","bnb","OATH","0xd3c6ceedd1cc7bd4304f72b011d53441d631e662",18),
+    ("edu-open-campus", "bnb", "EDU", "0xbdeae1ca48894a1759a8374d63925f21f2ee2639", 18),
+    ("id-space-id", "bnb", "ID", "0x2dff88a56767223a5529ea5960da7a3f5f766406", 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
 where contract_address not in (
     '0x2ab0e9e4ee70fff1fb9d67031e44f6410170d00e', -- bXEN has bad price feed.


### PR DESCRIPTION
add EDU and ID

# SPELLBOOK FREEZE

From June 22 to June 29, we will be freezing some Spellbook contributions for the migration to DuneSQL. We will not accept contributions to the lineage of the following models:

* dex.trades
* nft.trades
* labels
* token.erc20
* tokens.nft

Run the following command to see the list of affected files:

```
dbt ls --resource-type model --output path --select +dex_trades +labels +nft_trades +tokens_nft +tokens_erc20
```

Don't hesitate to reach out on Discord if you have any questions.

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
